### PR TITLE
Fix flatcc falls into endless loop

### DIFF
--- a/src/compiler/semantics.c
+++ b/src/compiler/semantics.c
@@ -1326,6 +1326,7 @@ static int process_table(fb_parser_t *P, fb_compound_type_t *ct)
             field_index[j]->link = field_index[i];
             j = i;
         }
+        field_index[max_id]->link = NULL;
     }
     if (key_count) {
         ct->symbol.flags |= fb_indexed;


### PR DESCRIPTION
write a schema to define a table which the first field has the max_id, flatcc falls into endless loop again.
e.g.
```
table x {
     b:int (id:2);
     a:int (id:0);
     c:int (id:1);
   } 
```
the original member list is 2->0->1 , the reordered member is  0->1->2 ( field with id:2 must link to null instead of id:0) unless a loop occurs in the list